### PR TITLE
Parallelize tile processing and disable AVX instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # ompiler & Linker settings
 CXX = g++
-CXXFLAGS = -I ./inc -I ./third-party/CImg -I ./third-party/libjpeg -I ./Data-Loader -std=c++11
+CXXFLAGS = -I ./inc -I ./third-party/CImg -I ./third-party/libjpeg -I ./Data-Loader -std=c++11 -mno-avx
 OPTFLAGS = -march=native -flto -funroll-loops -finline-functions -ffast-math -O3
 WARNINGS = -g -Wall
 LINKER = -L/usr/X11R6/lib -lm -lpthread -lX11 -L./third-party/libjpeg -ljpeg -lpng

--- a/inc/photo_mosaic.h
+++ b/inc/photo_mosaic.h
@@ -1,7 +1,9 @@
 #ifndef _PHOTO_MOSAIC_H_
 #define _PHOTO_MOSAIC_H_
 
+#include <future>
 #include <vector>
+#include <chrono>
 #include <map>
 #include "image.h"
 #include "rgb_image.h"


### PR DESCRIPTION
This pull request includes two commits. 

The first commit parallelizes the tile processing in the `set_tiles` method of the `PhotoMosaic` class to improve performance. It uses `std::thread::hardware_concurrency()` to determine the maximum number of threads supported by the hardware. 

The second commit adds the `-mno-avx` flag to the `CXXFLAGS` in the Makefile to disable AVX instructions during compilation, ensuring that the valgrind check works normally.